### PR TITLE
Migrando de CoreCompat para System.Drawing.Common

### DIFF
--- a/BoletoNetCore/BoletoImpressao/BoletoBancario.cs
+++ b/BoletoNetCore/BoletoImpressao/BoletoBancario.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+using System.Drawing.Imaging;
 //Envio por email
 using System.IO;
 using System.Net.Mail;
@@ -738,15 +739,15 @@ namespace BoletoNetCore
             //Salvo a imagem apenas 1 vez
             if (!File.Exists(fnBarra))
             {
-                var imgConverter = new ImageConverter();
-                var imgBuffer = (byte[])imgConverter.ConvertTo(Html.barra, typeof(byte[]));
-                var ms = new MemoryStream(imgBuffer);
-
-                using (Stream stream = File.Create(fnBarra))
+                using (var ms = new MemoryStream())
                 {
-                    CopiarStream(ms, stream);
-                    ms.Flush();
-                    ms.Dispose();
+                    Html.barra.Save(ms, ImageFormat.Bmp);
+                    using (Stream stream = File.Create(fnBarra))
+                    {
+                        CopiarStream(ms, stream);
+                        ms.Flush();
+                        ms.Dispose();
+                    }
                 }
             }
 

--- a/BoletoNetCore/BoletoNetCore.csproj
+++ b/BoletoNetCore/BoletoNetCore.csproj
@@ -26,8 +26,8 @@
     <EmbeddedResource Include="Imagens/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreCompat.System.Drawing.v2" Version="5.2.0-preview1-r131" />
     <PackageReference Include="NReco.PdfGenerator.LT" Version="1.1.15" />
+    <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Html.Designer.cs">

--- a/BoletoNetCore/Util/Utils.cs
+++ b/BoletoNetCore/Util/Utils.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Globalization;
+using System.IO;
 
 namespace BoletoNetCore
 {
@@ -197,6 +198,15 @@ namespace BoletoNetCore
             }
         }
 
+        public static byte[] GetBytes(this Image image, ImageFormat format)
+        {
+            using (var ms = new MemoryStream())
+            {
+                image.Save(ms, format);
+                return ms.ToArray();
+            }
+        }
+
         /// <summary>
         /// Converte uma imagem em array de bytes.
         /// </summary>
@@ -209,11 +219,7 @@ namespace BoletoNetCore
 
             byte[] bytes;
             if (image.GetType().ToString() == "System.Drawing.Image")
-            {
-                ImageConverter converter = new ImageConverter();
-                bytes = (byte[])converter.ConvertTo(image, typeof(byte[]));
-                return bytes;
-            }
+                return image.GetBytes(ImageFormat.Bmp);
             else if (image.GetType().ToString() == "System.Drawing.Bitmap")
             {
                 bytes = (byte[])TypeDescriptor.GetConverter(image).ConvertTo(image, typeof(byte[]));


### PR DESCRIPTION
Fixes #10.

Migração teve sucesso imediato em tudo, menos `ImageConverter`. Implementei uma solução substituta para esse caso.

Por favor, verifique se o formato de imagem a ser utilizado para código de barras deveria mesmo ser `BMP`.

Build e testes estão passando, mas não cheguei a executar nada. Seria interessante testar, principalmente a parte de `ImageConverter`.